### PR TITLE
changing shebang line for mac compatability

### DIFF
--- a/framework/bin/bugsinpy-checkout
+++ b/framework/bin/bugsinpy-checkout
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 framework_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/framework/bin/bugsinpy-compile
+++ b/framework/bin/bugsinpy-compile
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 usage="-w work_dir
              The working directory to compile the project. Default will be the current directory.
 "
@@ -53,7 +54,7 @@ fi
 rm -r -f env/
 
 ###Add environment
-python -m venv env
+python3 -m venv env
 
 ###Activate environment
 if [ -d "env/Scripts" ]; then

--- a/framework/bin/bugsinpy-coverage
+++ b/framework/bin/bugsinpy-coverage
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage="-w work_dir
              The working directory to run the test. Default will be the current directory.

--- a/framework/bin/bugsinpy-fuzz
+++ b/framework/bin/bugsinpy-fuzz
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 usage="-p project_name
              The name of the project from bugsinpy.
         -i bug_id

--- a/framework/bin/bugsinpy-info
+++ b/framework/bin/bugsinpy-info
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 framework_location="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 

--- a/framework/bin/bugsinpy-mutation
+++ b/framework/bin/bugsinpy-mutation
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 usage="-w work_dir
              The working directory to run the test. Default will be the current directory.
        -t target

--- a/framework/bin/bugsinpy-test
+++ b/framework/bin/bugsinpy-test
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 usage="-w work_dir
              The working directory to run the test. Default will be the current directory.


### PR DESCRIPTION
The command `command &>> file.txt` is equivalent to `command >> file.txt 2>&1`, but this alias was not added until version 4 of bash. On macs, the default installation (activated by `#!/bin/bash`) is an older version which causes the script to fail with a syntax error whenever `&>>`  is used. I resolved this by changing the line to `#!/usr/bin/env bash` which instead activates my default bash installation (version 5.1.16). I believe most mac users would run into the same problem. I tested this change on my linux laptop as well and it worked as expected, but I have not tested this on windows. 