### PR TITLE
Fixes -e option requires 1 argument.

### DIFF
--- a/framework/bin/bugsinpy-compile
+++ b/framework/bin/bugsinpy-compile
@@ -122,7 +122,7 @@ done < "$work_dir/bugsinpy_bug.info"
 #dos2unix $work_dir/bugsinpy_requirements.txt
 #pip install -r "$work_dir/bugsinpy_requirements.txt"
 if grep -q '[^[:space:]]' "$work_dir/bugsinpy_requirements.txt"; then
-    cat "$work_dir/bugsinpy_requirements.txt" | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 pip install
+    sed -e '/^\s*#.*$/d' -e '/^\s*$/d' $work_dir/bugsinpy_requirements.txt | xargs -I {} pip install {}
 fi
 
 for index in "${!run_setup[@]}"
@@ -135,7 +135,7 @@ done
 ###Install requirement
 #pip install -r "$work_dir/bugsinpy_requirements.txt"
 if grep -q '[^[:space:]]' "$work_dir/bugsinpy_requirements.txt"; then
-    cat "$work_dir/bugsinpy_requirements.txt" | sed -e '/^\s*#.*$/d' -e '/^\s*$/d' | xargs -n 1 pip install
+    sed -e '/^\s*#.*$/d' -e '/^\s*$/d' $work_dir/bugsinpy_requirements.txt | xargs -I {} pip install {}
 fi
 deactivate
 


### PR DESCRIPTION
The current approach uses `xargs -n 1`, which splits lines with spaces into two, resulting in broken installations for projects such as black, cookiecutter, keras, luigi, pandas, sanic, and thefuck. These projects use the `-e git+https://` syntax in their `requirements.txt`, which, according to the pip documentation, is used to install a project in editable mode (i.e., setuptools "develop mode") from a local project path or a VCS URL [1].

Without this fix, when executing `bugsinpy-compile`, we encounter the following error message:

```console
Usage:
    pip install [options] <requirement specifier> [package-index-options] ...
    pip install [options] -r <requirements file> [package-index-options] ...
    pip install [options] [-e] <vcs project url> ...
    pip install [options] [-e] <local project path> ...
    pip install [options] <archive url/path> ...

 -e option requires 1 argument.
```

However, with this fix, the requirements are installed properly using the `-e` parameter. For example, when installing `luigi`, we get the following output:

```console
Obtaining luigi from git+https://github.com/spotify/luigi.git@1164eb6b85b8a70f596dbb99452bec513e72c12e#egg=luigi
  Cloning https://github.com/spotify/luigi.git (to revision 1164eb6b85b8a70f596dbb99452bec513e72c12e) to ./src/luigi
  Running command git clone --filter=blob:none --quiet https://github.com/spotify/luigi.git /home/user/src/luigi
  Running command git rev-parse -q --verify 'sha^1164eb6b85b8a70f596dbb99452bec513e72c12e'
  Running command git fetch -q https://github.com/spotify/luigi.git 1164eb6b85b8a70f596dbb99452bec513e72c12e
  Running command git checkout -q 1164eb6b85b8a70f596dbb99452bec513e72c12e
  Resolved https://github.com/spotify/luigi.git to commit 1164eb6b85b8a70f596dbb99452bec513e72c12e
  Preparing metadata (setup.py) ... done
```

This fix ensures that the requirements are installed correctly, including projects that require the `-e` parameter, such as `luigi`.

[1] Reference: [pip_install - pip documentation](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-e)