### PR TITLE
Add Docker Support for BugsInPy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM python:3.12-slim-trixie
+
+# The installer requires curl (and certificates) to download the release archive
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git dos2unix vim
+
+# Download the latest installer
+ADD https://astral.sh/uv/install.sh /uv-installer.sh
+
+# Run the installer then remove it
+RUN sh /uv-installer.sh && rm /uv-installer.sh
+
+# Ensure the installed binary is on the `PATH`
+ENV PATH="/root/.local/bin/:$PATH"
+ENV BUGSINPY_HOME="/home/bugsinpy/"
+ENV PATH="$BUGSINPY_HOME/framework/bin:$PATH"
+
+# Set working directory
+WORKDIR /home
+
+# Default command
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,27 @@ The objective of this work is to support reproducible research on real-world Pyt
 2. Add BugsInPy executables path:
     - `export PATH=$PATH:<bugsinpy_path>/framework/bin`
 
+# Use Docker
+Clone the repository, build the Docker image, and start a container:
+
+```shell
+docker build -t bugsinpy .
+docker run -dt \
+    -v ./framework:/home/bugsinpy/framework \
+    -v ./projects:/home/bugsinpy/projects \
+    -v ./workspace:/home/workspace
+    --name {your_container_name} bugsinpy
+docker exec -it {your_container_name} bash
+```
+Replace `{your_container_name}` with your preferred container name.
+When working inside the container, if you checkout source code to `/home/workspace/`, it will be accessible on your host machine at `./workspace` due to the mounted volume. For example:
+
+```shell
+bugsinpy-checkout -p youtube-dl -v 0 -i 2 -w /home/workspace
+```
+
+This command checks out the specified bug to `/home/workspace` in the container, which corresponds to `./workspace` on your host.
+
 # BugsInPy Command
 Command | Description
 --- | ---


### PR DESCRIPTION
This PR introduces a **Dockerfile** and updates the **README.md** to simplify environment setup and improve reproducibility for BugsInPy users.

## Dockerfile

A new `Dockerfile` is added to provide a lightweight and ready-to-use environment based on `python:3.12-slim-trixie`.

**Key features:**
* Installs essential utilities: `curl`, `ca-certificates`, `git`, `dos2unix`, and `vim`
* Downloads and installs **uv** (Python package manager) from [astral.sh](https://astral.sh/uv/)
* Sets up environment variables for:
  * `BUGSINPY_HOME`
  * `PATH` (to include `framework/bin`)
* Sets `/home` as the working directory
* Launches a `bash` shell by default

## README Update

Added a new section **“Use Docker”** that explains how to:

1. Build the Docker image
2. Run a container with volume mounts for:
   * `framework`
   * `projects`
   * `workspace`
3. Execute commands inside the container, ensuring host–container synchronization (e.g., checking out a bug to `/home/workspace`).
