### PR TITLE
Small Readme fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ fuzz | Run a test input generation from specific bug
 - Help usage from checkout command:
     - `bugsinpy-checkout --help`
 - Checkout a buggy source code version (youtube-dl, bug 2, buggy version):
-    - `bugsinpy-checkout -p youtube-dl -v 0 -i 2 -w /temp/projects`
+    - `bugsinpy-checkout -p youtube-dl -v 0 -i 2 -w /tmp/projects`
 - Compile sources and tests, and run tests from current directory:
     - `bugsinpy-compile`
     - `bugsinpy-test`

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ docker build -t bugsinpy .
 docker run -dt \
     -v ./framework:/home/bugsinpy/framework \
     -v ./projects:/home/bugsinpy/projects \
-    -v ./workspace:/home/workspace
+    -v ./workspace:/home/workspace \
     --name {your_container_name} bugsinpy
 docker exec -it {your_container_name} bash
 ```


### PR DESCRIPTION
1. In the docker run command at the end of one line the `\` was missing.
2. The example directory for the checkout was `/temp/projects`  but [the default directory for temporary files on Unix-like systems](https://en.wikipedia.org/wiki/Unix_filesystem#Conventional_directory_layout) is called `tmp` and not `temp`. 