### PR TITLE
Automatically select the right Python version in Docker environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM python:3.12-slim-trixie
+FROM python:3.9-slim-trixie
 
 # The installer requires curl (and certificates) to download the release archive
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git dos2unix vim
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git dos2unix vim bzip2
 
 # Download the latest installer
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
@@ -9,8 +9,34 @@ ADD https://astral.sh/uv/install.sh /uv-installer.sh
 # Run the installer then remove it
 RUN sh /uv-installer.sh && rm /uv-installer.sh
 
-# Ensure the installed binary is on the `PATH`
+# Ensure uv installer is linked
 ENV PATH="/root/.local/bin/:$PATH"
+
+# micromamba for Legacy compilers --------------
+
+ADD https://micro.mamba.pm/api/micromamba/linux-64/latest /micromamba.tar.bz2
+RUN mkdir -p /opt/micromamba \
+ && tar -xjf /micromamba.tar.bz2 -C /opt/micromamba bin/micromamba \
+ && rm /micromamba.tar.bz2
+ENV MAMBA_ROOT_PREFIX=/opt/micromamba
+ENV PATH="/opt/micromamba/bin:${PATH}"
+
+# Create separate envs with pinned Python + pip
+RUN /opt/micromamba/bin/micromamba create -y -n py36 -c conda-forge python=3.6 pip && \
+    /opt/micromamba/bin/micromamba create -y -n py37 -c conda-forge python=3.7 pip && \
+    /opt/micromamba/bin/micromamba create -y -n py38 -c conda-forge python=3.8 pip && \
+    /opt/micromamba/bin/micromamba clean -a -y
+
+# Expose python3.X and pip3.X shims
+RUN ln -sf /opt/micromamba/envs/py36/bin/python /usr/local/bin/python3.6 && \
+    ln -sf /opt/micromamba/envs/py37/bin/python /usr/local/bin/python3.7 && \
+    ln -sf /opt/micromamba/envs/py38/bin/python /usr/local/bin/python3.8 && \
+    ln -sf /opt/micromamba/envs/py36/bin/pip    /usr/local/bin/pip3.6    && \
+    ln -sf /opt/micromamba/envs/py37/bin/pip    /usr/local/bin/pip3.7    && \
+    ln -sf /opt/micromamba/envs/py38/bin/pip    /usr/local/bin/pip3.8
+# ---
+
+# Ensure the installed binary is on the `PATH`
 ENV BUGSINPY_HOME="/home/bugsinpy/"
 ENV PATH="$BUGSINPY_HOME/framework/bin:$PATH"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-slim-trixie
 
 # The installer requires curl (and certificates) to download the release archive
-RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git dos2unix vim bzip2
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates git nano dos2unix bzip2 build-essential
 
 # Download the latest installer
 ADD https://astral.sh/uv/install.sh /uv-installer.sh
@@ -44,4 +44,4 @@ ENV PATH="$BUGSINPY_HOME/framework/bin:$PATH"
 WORKDIR /home
 
 # Default command
-CMD ["bash"]
+CMD ["/bin/bash"]

--- a/framework/bin/bugsinpy-compile
+++ b/framework/bin/bugsinpy-compile
@@ -43,6 +43,17 @@ elif [[ ! -e "$work_dir/bugsinpy_run_test.sh" ]]; then
    exit
 fi
 
+# Read python version -------
+DONE=false
+until $DONE ;do
+read || DONE=true
+if [[ "$REPLY" == "python_version"* ]]; then
+   PYVER="$(cut -d'"' -f 2 <<< $REPLY)"
+fi
+done < "$work_dir/bugsinpy_bug.info"
+PYVER=${PYVER%.*}
+
+
 ###Check dos2unix
 #check_dos2unix=$(dos2unix --version 2>&1)
 #if [ "$check_dos2unix" == *"not found"* ]; then
@@ -54,7 +65,8 @@ fi
 rm -r -f env/
 
 ###Add environment
-python3 -m venv env
+echo "python${PYVER} -m venv env"
+python${PYVER} -m venv env
 
 ###Activate environment
 if [ -d "env/Scripts" ]; then

--- a/projects/PySnooper/bugs/1/setup.sh
+++ b/projects/PySnooper/bugs/1/setup.sh
@@ -1,1 +1,2 @@
 python setup.py install
+pip install python_toolbox

--- a/projects/ansible/bugs/1/setup.sh
+++ b/projects/ansible/bugs/1/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/10/setup.sh
+++ b/projects/ansible/bugs/10/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/11/setup.sh
+++ b/projects/ansible/bugs/11/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/12/setup.sh
+++ b/projects/ansible/bugs/12/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/13/setup.sh
+++ b/projects/ansible/bugs/13/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/14/setup.sh
+++ b/projects/ansible/bugs/14/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/15/setup.sh
+++ b/projects/ansible/bugs/15/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/16/setup.sh
+++ b/projects/ansible/bugs/16/setup.sh
@@ -1,3 +1,3 @@
 python setup.py install
-pip3 install pytest==3.10.1
-pip3 install pytest-mock==1.2
+pip install pytest==3.10.1 mock
+pip install pytest-mock==1.2

--- a/projects/ansible/bugs/17/setup.sh
+++ b/projects/ansible/bugs/17/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/18/setup.sh
+++ b/projects/ansible/bugs/18/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/2/setup.sh
+++ b/projects/ansible/bugs/2/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/3/setup.sh
+++ b/projects/ansible/bugs/3/setup.sh
@@ -1,3 +1,3 @@
 python setup.py install
-pip3 install pytest==3.10.1
-pip3 install pytest-mock==1.2
+pip install pytest==3.10.1 mock
+pip install pytest-mock==1.2

--- a/projects/ansible/bugs/4/setup.sh
+++ b/projects/ansible/bugs/4/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/5/setup.sh
+++ b/projects/ansible/bugs/5/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/6/setup.sh
+++ b/projects/ansible/bugs/6/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/7/setup.sh
+++ b/projects/ansible/bugs/7/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/8/setup.sh
+++ b/projects/ansible/bugs/8/setup.sh
@@ -1,2 +1,2 @@
 python setup.py install
-pip3 install pytest==3.10.1
+pip install pytest==3.10.1 mock

--- a/projects/ansible/bugs/9/setup.sh
+++ b/projects/ansible/bugs/9/setup.sh
@@ -1,3 +1,3 @@
 python setup.py install
-pip3 install pytest==3.10.1
-pip3 install pytest-mock==1.2
+pip install pytest==3.10.1 mock
+pip install pytest-mock==1.2


### PR DESCRIPTION
Hey!

When trying to reproduce some bugs, I noticed that some bugs could not be reproduced under Python 3.12. (or even Python 3.9) and required the specific Python version to be installed. This problem is also well documented [here](https://github.com/atom-sw/fauxpy-experiments). 

I think it would be nice to have a Docker environment that automatically "compiles" the code with the right Python version. Therefore, I started to prepare the pull request. 

I mark this as a draft because I did not completely tested it on all bugs by now, but please let me know if you have any concerns with this change.

Best,
Cedric