### PR TITLE
Change directory to work_dir before environment creation

### DIFF
--- a/framework/bin/bugsinpy-compile
+++ b/framework/bin/bugsinpy-compile
@@ -50,6 +50,8 @@ fi
 #   exit
 #fi
 
+cd "$work_dir"
+
 ###Remove environment if exist
 rm -r -f env/
 


### PR DESCRIPTION
The compile script creates the virtual environment in the current working directory regardless of the `-w work_dir` parameter. Other scripts already include a `cd` command to switch to the work directory.