### PR TITLE
Fix git command for detecting changed files in multi-parent merge commits

### DIFF
--- a/framework/bin/bugsinpy-checkout
+++ b/framework/bin/bugsinpy-checkout
@@ -142,7 +142,7 @@ cd "$work_dir/$project_name"
 git reset --hard "$fix_commit"
 
 ###Copy updated files in the fixed version to temp
-check_file=$(git show --name-only 2>&1)
+check_file=$(git show --name-only --first-parent 2>&1)
 change_file_all=""
 while IFS= read -r line; do
    if [ "$line" != "" ]; then


### PR DESCRIPTION

When the fixed commit is a merge commit with multiple parents, the checkout script's `git show --name-only` command fails to list changed files because Git cannot determine which parent to compare against. As a result, some fixed checkout versions remain in a buggy state with updated tests, causing those tests to fail.

An example is the [bug 2 of luigi](https://github.com/soarsmu/BugsInPy/tree/master/projects/luigi/bugs/2), where the fix commit is [a merge commit](https://github.com/spotify/luigi/commit/24e85945ae39e5975491527e00c3f0f64b42ea6e) with two parents and running `git show --name-only` on it returns only the commit message:

```console
$ git show --name-only
commit 24e85945ae39e5975491527e00c3f0f64b42ea6e (HEAD)
Merge: baa54c9f 5d9d38df
Author: Honnix <honnix@users.noreply.github.com>
Date:   Thu May 9 13:23:23 2019 +0200

    Merge pull request #2705 from spotify/claire/fix_dataflow_bq_return_type

    Fix BigQueryTarget parsing in beam_dataflow module
```

Changing the command to `git show --name-only --first-parent` returns the expected [two changed files](https://github.com/spotify/luigi/commit/24e85945ae39e5975491527e00c3f0f64b42ea6e.diff):

```console
$ git show --name-only --first-parent
commit 24e85945ae39e5975491527e00c3f0f64b42ea6e (HEAD)
Merge: baa54c9f 5d9d38df
Author: Honnix <honnix@users.noreply.github.com>
Date:   Thu May 9 13:23:23 2019 +0200

    Merge pull request #2705 from spotify/claire/fix_dataflow_bq_return_type

    Fix BigQueryTarget parsing in beam_dataflow module

luigi/contrib/beam_dataflow.py
test/contrib/beam_dataflow_test.py
```
