### PR TITLE
Fix keras 12 buggy commit id

### DIFF
--- a/projects/keras/bugs/12/bug.info
+++ b/projects/keras/bugs/12/bug.info
@@ -1,4 +1,4 @@
 python_version="3.7.3"
-buggy_commit_id="6dff721a3a8755356b2e89d02ef63ad8ab38ec95"
+buggy_commit_id="3fcb5e38a1470bf0aa5fa1b9b0dd712b7992e493"
 fixed_commit_id="6dff721a3a8755356b2e89d02ef63ad8ab38ec95"
 test_file="tests/keras/metrics_test.py"

--- a/projects/keras/bugs/12/bug_patch.txt
+++ b/projects/keras/bugs/12/bug_patch.txt
@@ -1,0 +1,22 @@
+diff --git a/keras/metrics.py b/keras/metrics.py
+index 8e3df1f365f8..b0c500b2c570 100644
+--- a/keras/metrics.py
++++ b/keras/metrics.py
+@@ -34,10 +34,13 @@ def categorical_accuracy(y_true, y_pred):
+ 
+ 
+ def sparse_categorical_accuracy(y_true, y_pred):
+-    # flatten y_true in case it's in shape (num_samples, 1) instead of (num_samples,)
+-    return K.cast(K.equal(K.flatten(y_true),
+-                          K.cast(K.argmax(y_pred, axis=-1), K.floatx())),
+-                  K.floatx())
++    # reshape in case it's in shape (num_samples, 1) instead of (num_samples,)
++    if K.ndim(y_true) == K.ndim(y_pred):
++        y_true = K.squeeze(y_true, -1)
++    # convert dense predictions to labels
++    y_pred_labels = K.argmax(y_pred, axis=-1)
++    y_pred_labels = K.cast(y_pred_labels, K.floatx())
++    return K.cast(K.equal(y_true, y_pred_labels), K.floatx())
+ 
+ 
+ def top_k_categorical_accuracy(y_true, y_pred, k=5):


### PR DESCRIPTION
Replaced the incorrect `buggy_commit_id` of keras 12 with the [parent hash](https://github.com/keras-team/keras/commit/6dff721a3a8755356b2e89d02ef63ad8ab38ec95) because it was the same as the `fixed_commit_id`. Also added the patch to `bug_patch.txt` as the file was empty.