### PR TITLE
Fix PySnooper 2 buggy commit id

### DIFF
--- a/projects/PySnooper/bugs/2/bug.info
+++ b/projects/PySnooper/bugs/2/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.1"
-buggy_commit_id="e21a31162f4c54be693d8ca8260e42393b39abd3"
+buggy_commit_id="81868cd0ba676035172a2ad493253c8c6ac9b4d4"
 fixed_commit_id="814abc34a098c1b98cb327105ac396f985d2413e"
 test_file="tests/test_pysnooper.py"


### PR DESCRIPTION
The correct buggy id of PySnooper 2 is different: https://github.com/cool-RR/PySnooper/commit/814abc34a098c1b98cb327105ac396f985d2413e
Current one causes both the buggy and fixed versions to error out:

```
==================================== ERRORS ====================================
___________________ ERROR collecting tests/test_pysnooper.py ___________________
tests/test_pysnooper.py:11: in <module>
    from pysnooper.utils import truncate
pysnooper/__init__.py:20: in <module>
    from .tracer import Tracer as snoop
pysnooper/tracer.py:18: in <module>
    if pycompat.PY2:
E   AttributeError: module 'pysnooper.pycompat' has no attribute 'PY2'
=========================== short test summary info ============================
ERROR tests/test_pysnooper.py - AttributeError: module 'pysnooper.pycompat' h...
3 warnings, 1 error in 1.40s
```