### PR TITLE
Expand pandas buggy commit ids

### DIFF
--- a/projects/pandas/bugs/1/bug.info
+++ b/projects/pandas/bugs/1/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="3fd150c"
+buggy_commit_id="3fd150c9e6e3a1a39622577745a7d821611c09d3"
 fixed_commit_id="e41ee47a90bb1d8a1fa28fcefcd45ed8ef5cb946"
 test_file="pandas/tests/dtypes/test_dtypes.py"

--- a/projects/pandas/bugs/10/bug.info
+++ b/projects/pandas/bugs/10/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="de8ca78"
+buggy_commit_id="de8ca78921fa6aa003a047a14ffaa03a5f3b86ac"
 fixed_commit_id="e1ee2b0679e5999c993a787606d30e75faaba7a2"
 test_file="pandas/tests/series/methods/test_update.py"

--- a/projects/pandas/bugs/100/bug.info
+++ b/projects/pandas/bugs/100/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8806ed7" 
+buggy_commit_id="8806ed7120fed863b3cd7d3d5f377ec4c81739d0"
 fixed_commit_id="2b1b3da4c68fdaf9637d12706c5ba3de1a9b20de"  
 test_file="pandas/tests/frame/methods/test_pct_change.py" 

--- a/projects/pandas/bugs/101/bug.info
+++ b/projects/pandas/bugs/101/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="765d8db" 
+buggy_commit_id="765d8db7eef1befef33f4c99d3e206d26e8444c8"
 fixed_commit_id="27b713ba677869893552cbeff6bc98a5dd231950"  
 test_file="pandas/tests/dtypes/test_common.py" 

--- a/projects/pandas/bugs/102/bug.info
+++ b/projects/pandas/bugs/102/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="efaadd5" 
+buggy_commit_id="efaadd502aba9af6322e7938b7034740fcca753b"
 fixed_commit_id="765d8db7eef1befef33f4c99d3e206d26e8444c8"  
 test_file="pandas/tests/frame/test_constructors.py" 

--- a/projects/pandas/bugs/103/bug.info
+++ b/projects/pandas/bugs/103/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="d1f82f7" 
+buggy_commit_id="d1f82f7b5e692f02b6fd7c43acd432370ca2eca5"
 fixed_commit_id="19578e364fb47ce10dd14174cffc3ecfea1a58cd"  
 test_file="pandas/tests/groupby/test_transform.py" 

--- a/projects/pandas/bugs/104/bug.info
+++ b/projects/pandas/bugs/104/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f738581" 
+buggy_commit_id="f738581fbb179fbe78bc4a4c81f7c31162c4a9e3"
 fixed_commit_id="8e9b3eee812b70197341c26c40200d8a1a77ed9c"  
 test_file="pandas/tests/groupby/test_function.py" 

--- a/projects/pandas/bugs/105/bug.info
+++ b/projects/pandas/bugs/105/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="7e6125a" 
+buggy_commit_id="7e6125a8758fa76cf93393eabd83ad07df779f1f"
 fixed_commit_id="cb5f9d1ff407f5ccef7c717e0c23bbd6ed96cf5f"  
 test_file="pandas/tests/arithmetic/test_period.py" 

--- a/projects/pandas/bugs/106/bug.info
+++ b/projects/pandas/bugs/106/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="114d552" 
+buggy_commit_id="114d55210a4434e3a0260d3660465eaa8d31ce9c"
 fixed_commit_id="e46026ff4669a30192b91e362ce8cdcbc9693870"  
 test_file="pandas/tests/indexes/multi/test_drop.py" 

--- a/projects/pandas/bugs/107/bug.info
+++ b/projects/pandas/bugs/107/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="47ac4b3" 
+buggy_commit_id="47ac4b37a5e2677ea3eb9d1c58f9f23d57859673"
 fixed_commit_id="fa4949f27ccfbc255bb8dbcd5ec5464b8663f1d2"  
 test_file="pandas/tests/frame/test_combine_concat.py" 

--- a/projects/pandas/bugs/108/bug.info
+++ b/projects/pandas/bugs/108/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="20e4c18" 
+buggy_commit_id="20e4c186191859dcde2437edacaee43d8d34dc46"
 fixed_commit_id="53a0dfd41a65a33dd7b0963734b24c749212e625"  
 test_file="pandas/tests/dtypes/cast/test_infer_dtype.py" 

--- a/projects/pandas/bugs/109/bug.info
+++ b/projects/pandas/bugs/109/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8b39de1" 
+buggy_commit_id="8b39de155840133844e8dbd2a10d621184bc5a37"
 fixed_commit_id="68b3eb4f5a7fbc223accbbeddbf03ec8ea31af00"  
 test_file="pandas/tests/arrays/categorical/test_analytics.py" 

--- a/projects/pandas/bugs/11/bug.info
+++ b/projects/pandas/bugs/11/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="1c88e6a"
+buggy_commit_id="1c88e6aff94cc9183909b7c110f554df42509073"
 fixed_commit_id="b7f061c3d24df943e16918ad3932e767f5639a38"
 test_file="pandas/tests/reshape/test_concat.py"

--- a/projects/pandas/bugs/110/bug.info
+++ b/projects/pandas/bugs/110/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="cceef8e" 
+buggy_commit_id="cceef8e83798f14504f71a3b8479e275d1b6a69d"
 fixed_commit_id="96bb151fe1a5b812ecab400adcd297d14fd0e0e4"  
 test_file="pandas/tests/indexing/test_categorical.py" 

--- a/projects/pandas/bugs/111/bug.info
+++ b/projects/pandas/bugs/111/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="28715a7" 
+buggy_commit_id="28715a7c79729ee8f5ef303d76b8e7c1ce1b64dd"
 fixed_commit_id="27836e93dc3c9d55c60282ccb15c88c42a340d87"  
 test_file="pandas/tests/indexing/test_categorical.py;pandas/tests/indexing/test_floats.py" 

--- a/projects/pandas/bugs/112/bug.info
+++ b/projects/pandas/bugs/112/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ebbe2a2" 
+buggy_commit_id="ebbe2a284208926326967a9a0bb5fa60639ed042"
 fixed_commit_id="8a354b7630f74739212725c38cbaa9b069191a88"  
 test_file="pandas/tests/frame/test_analytics.py" 

--- a/projects/pandas/bugs/113/bug.info
+++ b/projects/pandas/bugs/113/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b164624" 
+buggy_commit_id="b164624aa3a8170fd7d140122da391cbe32b7b8b"
 fixed_commit_id="8705aad961dd227d38ff93a39697547b98109c9d"  
 test_file="pandas/tests/extension/test_integer.py" 

--- a/projects/pandas/bugs/114/bug.info
+++ b/projects/pandas/bugs/114/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8f0310a" 
+buggy_commit_id="8f0310a4a9f49f4279240abb8101e8b12a124544"
 fixed_commit_id="9a222ea0300053ff46da984e3b3f68622ccba9c3"  
 test_file="pandas/tests/extension/decimal/test_decimal.py" 

--- a/projects/pandas/bugs/115/bug.info
+++ b/projects/pandas/bugs/115/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ed20822" 
+buggy_commit_id="ed20822a54e3863b393554ecca801654af105555"
 fixed_commit_id="386494d0dc851be9e86b1576f30fa8705df4d47b"  
 test_file="pandas/tests/series/test_missing.py" 

--- a/projects/pandas/bugs/116/bug.info
+++ b/projects/pandas/bugs/116/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="9333e3d" 
+buggy_commit_id="9333e3d8e360e0049f6aedca78721dda0449a871"
 fixed_commit_id="c4fa6a52f7737aecda08f6b0f2d6c27476298ae1"  
 test_file="pandas/tests/reshape/merge/test_merge_asof.py" 

--- a/projects/pandas/bugs/117/bug.info
+++ b/projects/pandas/bugs/117/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="fc100fe" 
+buggy_commit_id="fc100fea90bb8ee95aaf33e4218e98b3655535d4"
 fixed_commit_id="f98d2b6587b74c9a640b062d94911b199d962119"  
 test_file="pandas/tests/series/test_analytics.py" 

--- a/projects/pandas/bugs/118/bug.info
+++ b/projects/pandas/bugs/118/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6f1accd" 
+buggy_commit_id="6f1accd04ff6957b24648ee947dc103979dca350"
 fixed_commit_id="76e39ebcf584042fab4f224a6bd2c903bb0c8aff"  
 test_file="pandas/tests/reshape/test_melt.py" 

--- a/projects/pandas/bugs/119/bug.info
+++ b/projects/pandas/bugs/119/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3f69d62" 
+buggy_commit_id="3f69d6277c4961631b606a62cad117daa6b3c052"
 fixed_commit_id="e0bd4d5dd07cc481cb52de3cf3c7bf199cb2df07"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/12/bug.info
+++ b/projects/pandas/bugs/12/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="9bd296c"
+buggy_commit_id="9bd296ce0a5316c34e60e9775fc7c4e0a9a71152"
 fixed_commit_id="8aa707298428801199280b2b994632080591700a"
 test_file="pandas/tests/frame/methods/test_cov_corr.py"

--- a/projects/pandas/bugs/120/bug.info
+++ b/projects/pandas/bugs/120/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="2b0cac7" 
+buggy_commit_id="2b0cac7d90ee9797194a55fb186743c00fc6d46a"
 fixed_commit_id="c5a1f9e2c373ced9ef2f02ab64d11eaa7b4248f2"  
 test_file="pandas/tests/groupby/test_categorical.py" 

--- a/projects/pandas/bugs/121/bug.info
+++ b/projects/pandas/bugs/121/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ad4c4d5" 
+buggy_commit_id="ad4c4d513cbfbb7eff0f326897e3cca71c667924"
 fixed_commit_id="958756af5cb40658e975a70d29089b68aea93040"  
 test_file="pandas/tests/frame/test_replace.py" 

--- a/projects/pandas/bugs/122/bug.info
+++ b/projects/pandas/bugs/122/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="07e6b9d" 
+buggy_commit_id="07e6b9db8ab464f90608b8dea7210ba0481a1982"
 fixed_commit_id="30059081e946a2020d08d49bf4fa7b771d10089a"  
 test_file="pandas/tests/internals/test_internals.py" 

--- a/projects/pandas/bugs/123/bug.info
+++ b/projects/pandas/bugs/123/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b6d64d2" 
+buggy_commit_id="b6d64d2c01c93745fc56baa3c05987f60c8dbfe7"
 fixed_commit_id="17fe9a467581ca39f44c89876ebd0d38b9ca77ea"  
 test_file="pandas/tests/indexes/test_numeric.py;pandas/tests/indexes/test_range.py" 

--- a/projects/pandas/bugs/124/bug.info
+++ b/projects/pandas/bugs/124/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="deceebe" 
+buggy_commit_id="deceebe01aa9a3e4631828cb5b7453b25e9620bb"
 fixed_commit_id="5a0f7e9e03976020ba52a7473f90cb1c8a4354c0"  
 test_file="pandas/tests/test_strings.py" 

--- a/projects/pandas/bugs/125/bug.info
+++ b/projects/pandas/bugs/125/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="e639af2" 
+buggy_commit_id="e639af2afd18b90ab9063df9c1927ae1f357a418"
 fixed_commit_id="fb08ceeeeba2ba62f92b47d424b3ae83c20ed9db"  
 test_file="pandas/tests/arrays/categorical/test_algos.py;pandas/tests/frame/test_replace.py" 

--- a/projects/pandas/bugs/126/bug.info
+++ b/projects/pandas/bugs/126/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="29be383" 
+buggy_commit_id="29be383d1ff9355cd7b3031f595201af863406e5"
 fixed_commit_id="e639af2afd18b90ab9063df9c1927ae1f357a418"  
 test_file="pandas/tests/frame/test_combine_concat.py" 

--- a/projects/pandas/bugs/127/bug.info
+++ b/projects/pandas/bugs/127/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f7d6b58" 
+buggy_commit_id="f7d6b584f83babf3f5c6d1610f6150d809be460f"
 fixed_commit_id="710d82c0d393c9031e469ec0371660d8187b7dc3"  
 test_file="pandas/tests/series/test_timeseries.py" 

--- a/projects/pandas/bugs/128/bug.info
+++ b/projects/pandas/bugs/128/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="794a1c2" 
+buggy_commit_id="794a1c21cfcbadd7a36653d9c8184868442be35b"
 fixed_commit_id="112e6b8d054f9adc1303138533ed6506975f94db"  
 test_file="pandas/tests/io/json/test_readlines.py" 

--- a/projects/pandas/bugs/129/bug.info
+++ b/projects/pandas/bugs/129/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="5b580fb" 
+buggy_commit_id="5b580fb72fecb1508f8264b1cc451e63547cc26a"
 fixed_commit_id="82c9547ddcaf2fd70e00f1368731f14a03bbac88"  
 test_file="pandas/tests/arithmetic/test_timedelta64.py" 

--- a/projects/pandas/bugs/13/bug.info
+++ b/projects/pandas/bugs/13/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="08f9bd2"
+buggy_commit_id="08f9bd28216e25a8fbe2dc05e8b7407f7fe086da"
 fixed_commit_id="91150d976ac41bd93a0e6516b2090c534f91aff2"
 test_file="pandas/tests/arrays/categorical/test_missing.py"

--- a/projects/pandas/bugs/130/bug.info
+++ b/projects/pandas/bugs/130/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="7adc14a" 
+buggy_commit_id="7adc14a349984822d1270f2c4b09b66fe36a2df2"
 fixed_commit_id="8efc717e4652e1e4bfbc4455da1d40eb676eed91"  
 test_file="pandas/tests/groupby/test_value_counts.py" 

--- a/projects/pandas/bugs/131/bug.info
+++ b/projects/pandas/bugs/131/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="73745be" 
+buggy_commit_id="73745be202b25c2433469ddaf1df6ba3901714b4"
 fixed_commit_id="bf5848f111c92fc5c6c11a93a3bc2480f138f1b1"  
 test_file="pandas/tests/series/test_datetime_values.py" 

--- a/projects/pandas/bugs/132/bug.info
+++ b/projects/pandas/bugs/132/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="221c8a7" 
+buggy_commit_id="221c8a7a623bfabdeccfb62212e091ed37b4af5e"
 fixed_commit_id="bd8f07fb29d2ac819f4c8e8e1b8e6d40f8b0f40c"  
 test_file="pandas/tests/reductions/test_reductions.py" 

--- a/projects/pandas/bugs/133/bug.info
+++ b/projects/pandas/bugs/133/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="343544d" 
+buggy_commit_id="343544dae05176315806891ac2181a379b1394e9"
 fixed_commit_id="c983d52e3a3a8a191359814417f375b1dc8b04c1"  
 test_file="pandas/tests/frame/test_missing.py" 

--- a/projects/pandas/bugs/134/bug.info
+++ b/projects/pandas/bugs/134/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="da1401b" 
+buggy_commit_id="da1401b7acbbd3c9fc51e0c763c02601436bfaad"
 fixed_commit_id="b1eb97bdfe17f477600eef19e82d65480457bbf5"  
 test_file="pandas/tests/tseries/holiday/test_calendar.py" 

--- a/projects/pandas/bugs/135/bug.info
+++ b/projects/pandas/bugs/135/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="0df22b6" 
+buggy_commit_id="0df22b6de60e4e8786f608b732c2e34b35a66866"
 fixed_commit_id="f41219179de69fed5c2a4b7df821394af1aa6559"  
 test_file="pandas/tests/extension/decimal/test_decimal.py" 

--- a/projects/pandas/bugs/136/bug.info
+++ b/projects/pandas/bugs/136/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3954fa7" 
+buggy_commit_id="3954fa7b3c10729eb7fd5a13a92bf03e11e49b17"
 fixed_commit_id="6241b9d3b3b8fd688cf32e45539719f1b9ec25c1"  
 test_file="pandas/tests/reshape/merge/test_merge_asof.py" 

--- a/projects/pandas/bugs/137/bug.info
+++ b/projects/pandas/bugs/137/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a1b2c4b" 
+buggy_commit_id="a1b2c4b7c5b700166ebe9d2b5b4cf43f46c561cf"
 fixed_commit_id="48f1a67469c91c38e78ebb2648061fe73dd79e6b"  
 test_file="pandas/tests/extension/test_categorical.py;pandas/tests/reshape/merge/test_merge.py" 

--- a/projects/pandas/bugs/138/bug.info
+++ b/projects/pandas/bugs/138/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3dcbec5" 
+buggy_commit_id="3dcbec59ee9c4f91ef42745898178b1ff049bedb"
 fixed_commit_id="c59c2df94e5563819a824f49fa6f55636bdb4445"  
 test_file="pandas/tests/reshape/test_qcut.py" 

--- a/projects/pandas/bugs/139/bug.info
+++ b/projects/pandas/bugs/139/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="7705cd2" 
+buggy_commit_id="7705cd24a64776b04273b8fffd7225a944f7dc85"
 fixed_commit_id="0ffdbe36f0df732f2700cda4a84be758084ff901"  
 test_file="pandas/tests/groupby/test_categorical.py" 

--- a/projects/pandas/bugs/14/bug.info
+++ b/projects/pandas/bugs/14/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="e7b23d4"
+buggy_commit_id="e7b23d4c9453b62bb8185b13878364f275d0824b"
 fixed_commit_id="dd71064327721c1ec7366000f357b0c08bcec4d2"
 test_file="pandas/tests/arithmetic/test_datetime64.py;pandas/tests/arithmetic/test_timedelta64.py"

--- a/projects/pandas/bugs/140/bug.info
+++ b/projects/pandas/bugs/140/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3b19e1d" 
+buggy_commit_id="3b19e1ddbb0dab26c50711741bd3e1fe7012ea77"
 fixed_commit_id="4375daffeed16531bae3fdaf85324b590d1dcb59"  
 test_file="pandas/tests/groupby/test_apply.py" 

--- a/projects/pandas/bugs/141/bug.info
+++ b/projects/pandas/bugs/141/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b298696" 
+buggy_commit_id="b29869694c8d5081ca3b5b52b84fa4eefad10b85"
 fixed_commit_id="411dd249e755d7e281603fe3e0ab9e0e48383df9"  
 test_file="pandas/tests/indexes/test_range.py" 

--- a/projects/pandas/bugs/142/bug.info
+++ b/projects/pandas/bugs/142/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="7721f31" 
+buggy_commit_id="7721f31db87f5b4f4019babea9afaa64759f8225"
 fixed_commit_id="65815e6f33e25991e3d40a53c581ffb3c7daf70f"  
 test_file="pandas/tests/series/test_analytics.py" 

--- a/projects/pandas/bugs/143/bug.info
+++ b/projects/pandas/bugs/143/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="c13c13b" 
+buggy_commit_id="c13c13bc365912f0503ff6dba1a184349726f287"
 fixed_commit_id="df918becf698741861da0e9b7e810d477b0eb194"  
 test_file="pandas/tests/frame/test_indexing.py;pandas/tests/indexes/test_range.py" 

--- a/projects/pandas/bugs/144/bug.info
+++ b/projects/pandas/bugs/144/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b106108" 
+buggy_commit_id="b10610871a24c619995db400e9419eebf8ac34ed"
 fixed_commit_id="ffe6cfdbf82d663c3f77567bde11f1666de1df38"  
 test_file="pandas/tests/plotting/test_series.py" 

--- a/projects/pandas/bugs/145/bug.info
+++ b/projects/pandas/bugs/145/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3bd222d" 
+buggy_commit_id="3bd222d2987a1530b24a43301819414e5d5f6879"
 fixed_commit_id="f08a1e62e31fc11e7e5bd7bec72b7e6d86473423"  
 test_file="pandas/tests/frame/test_arithmetic.py" 

--- a/projects/pandas/bugs/146/bug.info
+++ b/projects/pandas/bugs/146/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="5ebb1e4" 
+buggy_commit_id="5ebb1e401006008d34a7aba1bc21e65c9333a7aa"
 fixed_commit_id="74cba561ece511e24abb5145225bf98a929ca6c9"  
 test_file="pandas/tests/dtypes/test_missing.py" 

--- a/projects/pandas/bugs/147/bug.info
+++ b/projects/pandas/bugs/147/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6acfc75" 
+buggy_commit_id="6acfc759d9179d300411aad83f2eece347b386c7"
 fixed_commit_id="773f341c8cc5a481a5a222508718034457ed1ebc"  
 test_file="pandas/tests/dtypes/test_dtypes.py" 

--- a/projects/pandas/bugs/148/bug.info
+++ b/projects/pandas/bugs/148/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4ac7f9d" 
+buggy_commit_id="4ac7f9de1f27fd35503c7532ee36b8607c5ce572"
 fixed_commit_id="95edcf1cbee630e42daca0404c44d8128ea156fb"  
 test_file="pandas/tests/frame/test_apply.py" 

--- a/projects/pandas/bugs/149/bug.info
+++ b/projects/pandas/bugs/149/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="0d69d91" 
+buggy_commit_id="0d69d91ecb73433d78815cdde653f9825bb1782f"
 fixed_commit_id="fa1364d1299a53093bc704f9c34c595b602a568b"  
 test_file="pandas/tests/io/test_gcs.py" 

--- a/projects/pandas/bugs/15/bug.info
+++ b/projects/pandas/bugs/15/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="f3fdab3"
+buggy_commit_id="f3fdab389a34e29d9a5915e64210ff0ff4b50b20"
 fixed_commit_id="71d610596ed128055614eb660f13c88168bfe22f"
 test_file="pandas/tests/indexes/datetimes/test_datetime.py"

--- a/projects/pandas/bugs/150/bug.info
+++ b/projects/pandas/bugs/150/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="54e9b75" 
+buggy_commit_id="54e9b756d2f8da99018ae2f02374c7ba14de164e"
 fixed_commit_id="d38627b5889db3f663cad339fe8f995af823b76b"  
 test_file="pandas/tests/dtypes/test_missing.py" 

--- a/projects/pandas/bugs/151/bug.info
+++ b/projects/pandas/bugs/151/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6110608" 
+buggy_commit_id="611060842f6e7d142c25f28f83f339442d2c1133"
 fixed_commit_id="5a227a410c520ceec2d94369a44e2ab774a40dc3"  
 test_file="pandas/tests/arrays/test_numpy.py" 

--- a/projects/pandas/bugs/152/bug.info
+++ b/projects/pandas/bugs/152/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="eb8cce0" 
+buggy_commit_id="eb8cce0bf999bd84460d336de0886e4d7c3c0b6c"
 fixed_commit_id="f61deb962ac0853595a43ad024c482b018d1792b"  
 test_file="pandas/tests/series/test_combine_concat.py" 

--- a/projects/pandas/bugs/153/bug.info
+++ b/projects/pandas/bugs/153/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ae22b80" 
+buggy_commit_id="ae22b809d2466599a30cf0882b8592f8fe764a46"
 fixed_commit_id="0c0a0cfbadcf01864d499599712edc9022eea12e"  
 test_file="pandas/tests/io/formats/test_to_csv.py" 

--- a/projects/pandas/bugs/154/bug.info
+++ b/projects/pandas/bugs/154/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="3f5b5c4" 
+buggy_commit_id="3f5b5c45f481fe0cbb704f6463578675318bb1f6"
 fixed_commit_id="e0c63b4cfaa821dfe310f4a8a1f84929ced5f5bd"  
 test_file="pandas/tests/groupby/test_groupby.py" 

--- a/projects/pandas/bugs/155/bug.info
+++ b/projects/pandas/bugs/155/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4252ab7" 
+buggy_commit_id="4252ab7718b06820ce485b8136294616e34ab168"
 fixed_commit_id="0bde7cedf46209a9fd4fa8c7f9fbce8b49aa78cd"  
 test_file="pandas/tests/window/test_rolling.py" 

--- a/projects/pandas/bugs/156/bug.info
+++ b/projects/pandas/bugs/156/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="42d6ee7" 
+buggy_commit_id="42d6ee7cd1d43dfc2054ec00d82135af87c33574"
 fixed_commit_id="05cc95971e56b503d4df9911a44cd60a7b74cc79"  
 test_file="pandas/tests/sparse/frame/test_frame.py" 

--- a/projects/pandas/bugs/157/bug.info
+++ b/projects/pandas/bugs/157/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b1c871c" 
+buggy_commit_id="b1c871ce4b5e76b3cffe1ebd4216d36379872352"
 fixed_commit_id="def01cf7bbb5ef8c9bf2e19737ea918e6a76a143"  
 test_file="pandas/tests/reshape/merge/test_merge_asof.py" 

--- a/projects/pandas/bugs/158/bug.info
+++ b/projects/pandas/bugs/158/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a76df79" 
+buggy_commit_id="a76df79498c452ace8ef21dfca8e5267169e92cb"
 fixed_commit_id="b1c871ce4b5e76b3cffe1ebd4216d36379872352"  
 test_file="pandas/tests/series/test_alter_axes.py" 

--- a/projects/pandas/bugs/159/bug.info
+++ b/projects/pandas/bugs/159/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="e55b698" 
+buggy_commit_id="e55b6980fd5c99087d0959952b22e74434e9f5e2"
 fixed_commit_id="62ab439b168d972546e06d329916c6be7ddd1288"  
 test_file="pandas/tests/arithmetic/test_numeric.py" 

--- a/projects/pandas/bugs/16/bug.info
+++ b/projects/pandas/bugs/16/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="f159734"
+buggy_commit_id="f1597341fc08aed366bc32bbfce113751fd5a698"
 fixed_commit_id="74e8607cb163b76ccf272ac72ae6b7848fe930c8"
 test_file="pandas/tests/arithmetic/test_period.py"

--- a/projects/pandas/bugs/160/bug.info
+++ b/projects/pandas/bugs/160/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="489d1ff" 
+buggy_commit_id="489d1ff8a1683f7f5549108dc7b04e43b5f32965"
 fixed_commit_id="fb62fcf91c874e9c24fa83693c4e6e613f35f864"  
 test_file="pandas/tests/test_expressions.py" 

--- a/projects/pandas/bugs/161/bug.info
+++ b/projects/pandas/bugs/161/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a818281" 
+buggy_commit_id="a818281a45f7b5bd24f050e5d6868894c5108db6"
 fixed_commit_id="ca5198a6daa7757e398112a17ccadc9e7d078d96"  
 test_file="pandas/tests/series/test_missing.py" 

--- a/projects/pandas/bugs/162/bug.info
+++ b/projects/pandas/bugs/162/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="341043d" 
+buggy_commit_id="341043d25e38f6f6f84b4609b2ab7feb96df7789"
 fixed_commit_id="640d9e1f5fe8ab64d1f6496b8216c28185e53225"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/163/bug.info
+++ b/projects/pandas/bugs/163/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="61819ab" 
+buggy_commit_id="61819aba14dd7b3996336aaed84d07cd936d92b5"
 fixed_commit_id="f669f94a186ea444cc771985a915e90eecf218a9"  
 test_file="pandas/tests/window/test_rolling.py" 

--- a/projects/pandas/bugs/164/bug.info
+++ b/projects/pandas/bugs/164/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ac69333" 
+buggy_commit_id="ac693331400bce4747c63aa76c53c6e3488933ae"
 fixed_commit_id="61819aba14dd7b3996336aaed84d07cd936d92b5"  
 test_file="pandas/tests/indexes/datetimes/test_tools.py" 

--- a/projects/pandas/bugs/165/bug.info
+++ b/projects/pandas/bugs/165/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="9fe8a0f" 
+buggy_commit_id="9fe8a0ffaed2f4df3f49a61c9d680d8a87497a90"
 fixed_commit_id="9b1c005142fed227081dd454eab1a414168d458e"  
 test_file="pandas/tests/arithmetic/test_datetime64.py" 

--- a/projects/pandas/bugs/166/bug.info
+++ b/projects/pandas/bugs/166/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4056ded" 
+buggy_commit_id="4056dedc79fbd6e0640e2c76cece1a2fe314675e"
 fixed_commit_id="d44fb07063e9a8bd8a209ddce35b40d8a56c8d02"  
 test_file="pandas/tests/frame/test_join.py" 

--- a/projects/pandas/bugs/167/bug.info
+++ b/projects/pandas/bugs/167/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6af6d51" 
+buggy_commit_id="6af6d5133c3172618bb550c7aba16eabc5e362c5"
 fixed_commit_id="226398224d260d908a1f3d0f23c16fa9ffc8f9b0"  
 test_file="pandas/tests/indexes/datetimes/test_partial_slicing.py" 

--- a/projects/pandas/bugs/168/bug.info
+++ b/projects/pandas/bugs/168/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="2de4fbb" 
+buggy_commit_id="2de4fbb940fccc8e42d48b23562b0b6b1a5434de"
 fixed_commit_id="1fa1ad91b29c5474cbb86cbcbcdcd50537cad0ae"  
 test_file="pandas/tests/groupby/test_groupby.py" 

--- a/projects/pandas/bugs/169/bug.info
+++ b/projects/pandas/bugs/169/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4d9016e" 
+buggy_commit_id="4d9016eea8effc58f12a6a921408eb8f48afad7e"
 fixed_commit_id="01babb590cb15ef5c6e9ad890ea580a5112e6999"  
 test_file="pandas/tests/frame/test_quantile.py" 

--- a/projects/pandas/bugs/17/bug.info
+++ b/projects/pandas/bugs/17/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="1e5ff23"
+buggy_commit_id="1e5ff233c559ecb2f14fdb9c8d9537db3a02ce1d"
 fixed_commit_id="afb04645b5b3361814f7d00ef68ce8d68e19ddb8"
 test_file="pandas/tests/indexes/datetimes/test_insert.py"

--- a/projects/pandas/bugs/18/bug.info
+++ b/projects/pandas/bugs/18/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="e008a0a"
+buggy_commit_id="e008a0a7ac9f4e11cc8e66d7d5b140253936e68c"
 fixed_commit_id="cb71376385c33270fa1922aec9eb6c49de4336f4"
 test_file="pandas/tests/window/test_base_indexer.py"

--- a/projects/pandas/bugs/19/bug.info
+++ b/projects/pandas/bugs/19/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="17dc6b0"
+buggy_commit_id="17dc6b09593164fe3f3a9c1ca59aba7484053622"
 fixed_commit_id="c6a1638bcd99df677a8f76f036c0b30027eb243c"
 test_file="pandas/tests/indexing/multiindex/test_loc.py;pandas/tests/indexing/multiindex/test_slice.py;pandas/tests/series/indexing/test_getitem.py"

--- a/projects/pandas/bugs/2/bug.info
+++ b/projects/pandas/bugs/2/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="2740fb4"
+buggy_commit_id="2740fb44e5e2ff64087ca7de5999eb30352722f0"
 fixed_commit_id="55e8891f6d33be14e0db73ac06513129503f995c"
 test_file="pandas/tests/indexing/test_scalar.py"

--- a/projects/pandas/bugs/20/bug.info
+++ b/projects/pandas/bugs/20/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="ea09d50"
+buggy_commit_id="ea09d504c98e9bf2caf274a20ba66d59f0024007"
 fixed_commit_id="92afd5c2c08216e4e9c80eb6b92b1660f91846e0"
 test_file="pandas/tests/tseries/offsets/test_yqm_offsets.py"

--- a/projects/pandas/bugs/21/bug.info
+++ b/projects/pandas/bugs/21/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="4071c3b"
+buggy_commit_id="4071c3b872e4ef98a2a2d7c752dd5d2030c4df6e"
 fixed_commit_id="56d0934092b8296c90f940c56fce3b731e0de81b"
 test_file="pandas/tests/series/indexing/test_boolean.py;pandas/tests/series/indexing/test_getitem.py"

--- a/projects/pandas/bugs/22/bug.info
+++ b/projects/pandas/bugs/22/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="38b669a"
+buggy_commit_id="38b669a206b151e0a2bb985200d4a493c4ac078f"
 fixed_commit_id="299e27da8a75d02d84870c1ca5971f4dd0f046e6"
 test_file="pandas/tests/window/test_base_indexer.py"

--- a/projects/pandas/bugs/23/bug.info
+++ b/projects/pandas/bugs/23/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="ab9f3c9"
+buggy_commit_id="ab9f3c91eac2a9f8b1ba1c7525094c7934152a13"
 fixed_commit_id="38b669a206b151e0a2bb985200d4a493c4ac078f"
 test_file="pandas/tests/indexes/datetimes/test_setops.py"

--- a/projects/pandas/bugs/24/bug.info
+++ b/projects/pandas/bugs/24/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="91dcc3a"
+buggy_commit_id="91dcc3a59a06d2ef97b350442a9e6245f7bc662f"
 fixed_commit_id="6367bd23b935a85f1bcd2ae762c7f08433d0efbd"
 test_file="pandas/tests/indexes/datetimes/test_timezones.py"

--- a/projects/pandas/bugs/25/bug.info
+++ b/projects/pandas/bugs/25/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="ecc3b2e"
+buggy_commit_id="ecc3b2e8087faf3b34e5c4725d7dfad456ef7fb8"
 fixed_commit_id="73d614403759831814ef7ab83ef1e4aaa645b33a"
 test_file="pandas/tests/indexes/datetimes/test_misc.py"

--- a/projects/pandas/bugs/26/bug.info
+++ b/projects/pandas/bugs/26/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="13dc13f"
+buggy_commit_id="13dc13f12c0fca943979cde065b7484bb0e40d66"
 fixed_commit_id="70ca24680d3e51fa4b957366e8093b3cc755462d"
 test_file="pandas/tests/arrays/categorical/test_analytics.py"

--- a/projects/pandas/bugs/27/bug.info
+++ b/projects/pandas/bugs/27/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="6658d89"
+buggy_commit_id="6658d899bfb20aff8f1ab6d495cf3c229cd5c77a"
 fixed_commit_id="13dc13f12c0fca943979cde065b7484bb0e40d66"
 test_file="pandas/tests/indexes/datetimes/test_to_period.py"

--- a/projects/pandas/bugs/28/bug.info
+++ b/projects/pandas/bugs/28/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="40fd73a"
+buggy_commit_id="40fd73ab8f69cd316cb554043cba8e463424006d"
 fixed_commit_id="ef9b9387c88cf12b20dd8656dfedfc236e0f3352"
 test_file="pandas/tests/test_strings.py"

--- a/projects/pandas/bugs/29/bug.info
+++ b/projects/pandas/bugs/29/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="6e3537d"
+buggy_commit_id="6e3537dbab2b5d6344e969cf3ae18925acf745e9"
 fixed_commit_id="4334482c348c3adc69683c8332295e22092c1b57"
 test_file="pandas/tests/arrays/interval/test_interval.py;pandas/tests/series/methods/test_convert_dtypes.py"

--- a/projects/pandas/bugs/3/bug.info
+++ b/projects/pandas/bugs/3/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="45fee32"
+buggy_commit_id="45fee3278680e8da2724236cc93227bcb28585b1"
 fixed_commit_id="d3a6a3a58e1a6eb68b8b8399ff252b8f4501950e"
 test_file="pandas/tests/series/methods/test_to_period.py;pandas/tests/series/methods/test_to_timestamp.py"

--- a/projects/pandas/bugs/30/bug.info
+++ b/projects/pandas/bugs/30/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="60d6f28" 
+buggy_commit_id="60d6f289201faf507117e9c18e364726d0d2a7bd"
 fixed_commit_id="d857cd12b3ae11be788ba96015383a5b7464ecc9"  
 test_file="pandas/tests/io/json/test_pandas.py" 

--- a/projects/pandas/bugs/31/bug.info
+++ b/projects/pandas/bugs/31/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="45c13a9" 
+buggy_commit_id="45c13a9723b501e05719ef36e81836bf7e86ff4f"
 fixed_commit_id="8267427bfe567eec9a098aa8c071dddcc1d289f9"  
 test_file="pandas/tests/groupby/test_function.py" 

--- a/projects/pandas/bugs/32/bug.info
+++ b/projects/pandas/bugs/32/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="467e1c2" 
+buggy_commit_id="467e1c208f58effb62d983a1f455eb10aea629c3"
 fixed_commit_id="c82cb179affed1c1136431ce39e4c66f4f3a65c0"  
 test_file="pandas/tests/io/sas/test_xport.py" 

--- a/projects/pandas/bugs/33/bug.info
+++ b/projects/pandas/bugs/33/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="03dacc1" 
+buggy_commit_id="03dacc1ef0a74c78a6912923425c742edaca7d3f"
 fixed_commit_id="89d8aba76a2bb930e520590d145e3d67b2046e39"  
 test_file="pandas/tests/arrays/integer/test_function.py" 

--- a/projects/pandas/bugs/34/bug.info
+++ b/projects/pandas/bugs/34/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="02a134b" 
+buggy_commit_id="02a134b2e4b12d7815554467107794384ac2ae1a"
 fixed_commit_id="cf9ec7854ecb80709804178e769425f02ddf8c64"  
 test_file="pandas/tests/resample/test_datetime_index.py" 

--- a/projects/pandas/bugs/35/bug.info
+++ b/projects/pandas/bugs/35/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a7dd3ea" 
+buggy_commit_id="a7dd3ea371dc0e76e317ba6f0fa1f5daacd3eb8e"
 fixed_commit_id="f10ec595eccaf86a9f52fe9683e1181a51ba675b"  
 test_file="pandas/tests/indexes/multi/test_get_level_values.py" 

--- a/projects/pandas/bugs/36/bug.info
+++ b/projects/pandas/bugs/36/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="cb41651" 
+buggy_commit_id="cb4165109aa4cdb3fb6dbdedd106d5f8cca0aaa2"
 fixed_commit_id="51f114b9882a5cf819efddb8be74524814f437e1"  
 test_file="pandas/tests/dtypes//test_missing.py" 

--- a/projects/pandas/bugs/37/bug.info
+++ b/projects/pandas/bugs/37/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="c69f7d8" 
+buggy_commit_id="c69f7d8ba74a3d9dac421655a729109777fb6512"
 fixed_commit_id="845c50c9e2ce611c773422ae9db7097fc3e5fba5"  
 test_file="pandas/tests/arrays/string_/test_string.py" 

--- a/projects/pandas/bugs/38/bug.info
+++ b/projects/pandas/bugs/38/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="c81d90f" 
+buggy_commit_id="c81d90f076016d6947c43e7fc302f500d526c96b"
 fixed_commit_id="e7ee418fa7a519225203fef23481c5fa35834dc3"  
 test_file="pandas/tests/frame/test_reshape.py" 

--- a/projects/pandas/bugs/39/bug.info
+++ b/projects/pandas/bugs/39/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8a5f291" 
+buggy_commit_id="8a5f2917e163e09e08af880819fdf44144b1a5fe"
 fixed_commit_id="a3097b5bd172e76dd3524eb5dbe18b6b4c22df50"  
 test_file="pandas/tests/frame//test_axis_select_reindex.py" 

--- a/projects/pandas/bugs/4/bug.info
+++ b/projects/pandas/bugs/4/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="cca710b"
+buggy_commit_id="cca710b42455664b44022e49f760ef790e9a3320"
 fixed_commit_id="2250ddfaff92abaff20a5bcd78315f5d4bd44981"
 test_file="pandas/tests/indexes/multi/test_join.py"

--- a/projects/pandas/bugs/40/bug.info
+++ b/projects/pandas/bugs/40/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="218cc30" 
+buggy_commit_id="218cc3012d7ebc30268a1f126e41eeeb5d319680"
 fixed_commit_id="8a5f2917e163e09e08af880819fdf44144b1a5fe"  
 test_file="pandas/tests/reshape/merge/test_merge.py" 

--- a/projects/pandas/bugs/41/bug.info
+++ b/projects/pandas/bugs/41/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="1b49f69" 
+buggy_commit_id="1b49f69741c276850e13e61d4cdcb2dec9cbd16f"
 fixed_commit_id="d4273353bc512e3b4e79c361b879633f33ec7289"  
 test_file="pandas/tests/indexing/test_iloc.py;pandas/tests/internals/test_internals.py" 

--- a/projects/pandas/bugs/42/bug.info
+++ b/projects/pandas/bugs/42/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b3a0fe4" 
+buggy_commit_id="b3a0fe401499230f968a3939bfbfb0ed3ac77aea"
 fixed_commit_id="05780a760400e42ce1b00200dd8204ae4f94044a"  
 test_file="pandas/tests/util/test_assert_frame_equal.py;pandas/tests/util/test_assert_series_equal.py" 

--- a/projects/pandas/bugs/43/bug.info
+++ b/projects/pandas/bugs/43/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="81149fb" 
+buggy_commit_id="81149fb76bb464f33b0f8505615d7f7952e70516"
 fixed_commit_id="be7bfe6ab7ae2cba056f61dea6c3b0226bf80082"  
 test_file="pandas/tests/frame/test_arithmetic.py" 

--- a/projects/pandas/bugs/44/bug.info
+++ b/projects/pandas/bugs/44/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="96d22d4" 
+buggy_commit_id="96d22d4f92acd007c1a7ad3d01a3e0b196884eb1"
 fixed_commit_id="50817487ce5b1a2c4896495509e2b53e22fa3212"  
 test_file="pandas/tests/indexes/test_base.py;pandas/tests/indexing/test_loc.py" 

--- a/projects/pandas/bugs/45/bug.info
+++ b/projects/pandas/bugs/45/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="74c5306" 
+buggy_commit_id="74c530642c11308df6162b4040ab04ac4e07db9f"
 fixed_commit_id="74f6579941fbe71cf7c033f53977047ac872e469"  
 test_file="pandas/tests/frame/test_constructors.py" 

--- a/projects/pandas/bugs/46/bug.info
+++ b/projects/pandas/bugs/46/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="e734449" 
+buggy_commit_id="e734449c95497d0e79d7529d94d82b4043a68f8b"
 fixed_commit_id="0ed6d538c38010bcbd540cd6413ae8e4b749d9e6"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/47/bug.info
+++ b/projects/pandas/bugs/47/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="1a5b11d" 
+buggy_commit_id="1a5b11d4ad8292a2c8393240e05822fcbf476ab5"
 fixed_commit_id="810a4e5b19616efb503767b4518083c9a59c11e6"  
 test_file="pandas/tests/frame/indexing/test_indexing.py;pandas/tests/indexing/test_loc.py" 

--- a/projects/pandas/bugs/48/bug.info
+++ b/projects/pandas/bugs/48/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="9bc3ee0" 
+buggy_commit_id="9bc3ee0e42218c1ea154835587edf52d0debce48"
 fixed_commit_id="9e7cb7c102655d0ba92d2561c178da9254d5cef5"  
 test_file="pandas/tests/groupby/test_function.py" 

--- a/projects/pandas/bugs/49/bug.info
+++ b/projects/pandas/bugs/49/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="113c255" 
+buggy_commit_id="113c2559ff10df03d9d8803ac84455904d408e9b"
 fixed_commit_id="37659d47a685ecc5f5117aa56526ece0106c6d0f"  
 test_file="pandas/tests/test_strings.py" 

--- a/projects/pandas/bugs/50/bug.info
+++ b/projects/pandas/bugs/50/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="ebf9668" 
+buggy_commit_id="ebf96681eebd11030640f7bc4d8693b3919cf802"
 fixed_commit_id="821aa25c9039e72da9a7b236cf2f9e7d549cbb7b"  
 test_file="pandas/tests/extension/test_categorical.py" 

--- a/projects/pandas/bugs/51/bug.info
+++ b/projects/pandas/bugs/51/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4800ab4" 
+buggy_commit_id="4800ab4d39bbb64bcbbef24db31517aa57d7d6b3"
 fixed_commit_id="ea1d8fadb95fbc7cafe036274006228400817fd4"  
 test_file="pandas/tests/reshape/merge/test_merge.py" 

--- a/projects/pandas/bugs/52/bug.info
+++ b/projects/pandas/bugs/52/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="20a84a5" 
+buggy_commit_id="20a84a5d8f554ecd52490e3111fd016d7b71a0e7"
 fixed_commit_id="7017599821e02ba95282848c12f7d3b5f2ce670a"  
 test_file="pandas/tests/groupby/test_function.py" 

--- a/projects/pandas/bugs/53/bug.info
+++ b/projects/pandas/bugs/53/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f9b49c8" 
+buggy_commit_id="f9b49c8ee4d711c721b41496f3e8d3d25d73231e"
 fixed_commit_id="020dcce17e3bd0983fca5b02556bd431140ab371"  
 test_file="pandas/tests/indexing/test_categorical.py;pandas/tests/indexing/test_loc.py" 

--- a/projects/pandas/bugs/54/bug.info
+++ b/projects/pandas/bugs/54/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="25443f0" 
+buggy_commit_id="25443f0960a31faf855134dc9cdb7ff01123be1d"
 fixed_commit_id="00e8e4ab0c5e4c7bfb3e356e660d9f088d4a82a4"  
 test_file="pandas/tests/dtypes/test_dtypes.py" 

--- a/projects/pandas/bugs/55/bug.info
+++ b/projects/pandas/bugs/55/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6ab00bc" 
+buggy_commit_id="6ab00bcb4d7fa66482fca8a34fc05c85d9101c87"
 fixed_commit_id="628dfba239865adc09c94108b288bcb60c619950"  
 test_file="pandas/tests/indexing/test_iloc.py" 

--- a/projects/pandas/bugs/56/bug.info
+++ b/projects/pandas/bugs/56/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="9e69040" 
+buggy_commit_id="9e69040f199266cd7a743dfd2f579f271337687f"
 fixed_commit_id="dafec63f2e138d0451dae5b37edea2e83f9adc8a"  
 test_file="pandas/tests/indexing/test_scalar.py" 

--- a/projects/pandas/bugs/57/bug.info
+++ b/projects/pandas/bugs/57/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="267d2d8" 
+buggy_commit_id="267d2d8635920581f362dbf5857f28cf4bea213c"
 fixed_commit_id="84444538a88721c5ee74de8836b716d3c1adc4b8"  
 test_file="pandas/tests/arrays/categorical/test_replace.py" 

--- a/projects/pandas/bugs/58/bug.info
+++ b/projects/pandas/bugs/58/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="634a41f" 
+buggy_commit_id="634a41f0dc703b9aa7314806484555dd687fff4d"
 fixed_commit_id="16684f2affaf901b42a12e50f9c29e7c034ad7ea"  
 test_file="pandas/tests/arrays/categorical/test_constructors.py" 

--- a/projects/pandas/bugs/59/bug.info
+++ b/projects/pandas/bugs/59/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="292a993" 
+buggy_commit_id="292a993d11decee64941c77472711f0d54777ac0"
 fixed_commit_id="8dd9fabd2ad9104e747084437b9ad436d5be087a"  
 test_file="pandas/tests/window/test_pairwise.py" 

--- a/projects/pandas/bugs/6/bug.info
+++ b/projects/pandas/bugs/6/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="21a10d1"
+buggy_commit_id="21a10d14df778999faad31107bed01074cac974a"
 fixed_commit_id="8cd8ed3657e52ad9f67e17b7f5c20f7340ab6a2c"
 test_file="pandas/tests/groupby/test_size.py"

--- a/projects/pandas/bugs/60/bug.info
+++ b/projects/pandas/bugs/60/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6bc2dca" 
+buggy_commit_id="6bc2dca9299b9a020a8f288ae41e01599c5f9e0d"
 fixed_commit_id="fcf7258c19b0a6a712f33fb0bcefdae426be7e7f"  
 test_file="pandas/tests/window/test_grouper.py" 

--- a/projects/pandas/bugs/61/bug.info
+++ b/projects/pandas/bugs/61/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="74dad82" 
+buggy_commit_id="74dad82827e9b13552df2d6d3fbbeb901821b53f"
 fixed_commit_id="f7e2b74f1bcc1d1cbebbc42481e33f0abb2843dc"  
 test_file="pandas/tests/indexing/test_indexing.py" 

--- a/projects/pandas/bugs/62/bug.info
+++ b/projects/pandas/bugs/62/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="46a77f6" 
+buggy_commit_id="46a77f689e27838200fd8a755e63f138e91bfc90"
 fixed_commit_id="74dad82827e9b13552df2d6d3fbbeb901821b53f"  
 test_file="pandas/tests/indexing/test_indexing.py" 

--- a/projects/pandas/bugs/63/bug.info
+++ b/projects/pandas/bugs/63/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="e5c65bf" 
+buggy_commit_id="e5c65bf80ef88c7c7ff30e561a794dd94be329c4"
 fixed_commit_id="e1ca66bae38b8026079dfcbe0edad5f278546608"  
 test_file="pandas/tests/indexing/test_scalar.py" 

--- a/projects/pandas/bugs/64/bug.info
+++ b/projects/pandas/bugs/64/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="31c1856" 
+buggy_commit_id="31c1856da8f88f494ebbcc8611211e3aa1aaa5a8"
 fixed_commit_id="d0c84ce57d23a409169daf7232ec7681e42363fe"  
 test_file="pandas/tests/io/excel/test_writers.py" 

--- a/projects/pandas/bugs/65/bug.info
+++ b/projects/pandas/bugs/65/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="2f70e41" 
+buggy_commit_id="2f70e412879a153201287fa5cd6346c34db3df90"
 fixed_commit_id="2f9a44635bd8d468cf008f2855ce2dcfb9e90586"  
 test_file="pandas/tests/io/parser/test_encoding.py" 

--- a/projects/pandas/bugs/66/bug.info
+++ b/projects/pandas/bugs/66/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f5409cb" 
+buggy_commit_id="f5409cb1469f62ba22348a1698165a34f1ab464f"
 fixed_commit_id="d84f9eb32aea33a8f790e8e365cf226eddd5c7a7"  
 test_file="pandas/tests/series/indexing/test_xs.py" 

--- a/projects/pandas/bugs/67/bug.info
+++ b/projects/pandas/bugs/67/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="c3e32d7" 
+buggy_commit_id="c3e32d739271355757f8cdba54c0daab2bca8226"
 fixed_commit_id="1996b17599731b889895b0e1edf758588c068fbb"  
 test_file="pandas/tests/frame/indexing/test_indexing.py" 

--- a/projects/pandas/bugs/68/bug.info
+++ b/projects/pandas/bugs/68/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="01582c4" 
+buggy_commit_id="01582c4ac98a735adcd69209a735a2baaf0c68aa"
 fixed_commit_id="d28db65bdba16e9400a16469ba2707f94ae63483"  
 test_file="pandas/tests/arrays/interval/test_interval.py" 

--- a/projects/pandas/bugs/69/bug.info
+++ b/projects/pandas/bugs/69/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="426d445" 
+buggy_commit_id="426d445025bd0b582da2a77208cabb03cee0e494"
 fixed_commit_id="948f95756c79543bb089a94a85e73011a3730b2d"  
 test_file="pandas/tests/indexes/test_numeric.py" 

--- a/projects/pandas/bugs/7/bug.info
+++ b/projects/pandas/bugs/7/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="27f365d" 
+buggy_commit_id="27f365d4d46880613ce1f125090f09e1be69a36a"
 fixed_commit_id="64336ff8414f8977ff94adb9a5bc000a3a4ef454"  
 test_file="pandas/tests/frame/indexing/test_indexing.py" 

--- a/projects/pandas/bugs/70/bug.info
+++ b/projects/pandas/bugs/70/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a05e6c9" 
+buggy_commit_id="a05e6c94563fb00bb30398bcac1236580fe2fa7c"
 fixed_commit_id="06ef193a5c1957c0a76e3e88bc7b834b38972c39"  
 test_file="pandas/tests/groupby/test_categorical.py" 

--- a/projects/pandas/bugs/71/bug.info
+++ b/projects/pandas/bugs/71/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="74a5edc" 
+buggy_commit_id="74a5edc3c5af8a22a44b03eabaa5cdadda0cd8fd"
 fixed_commit_id="a5daff22e6e37af4946c614f85b110905e063be3"  
 test_file="pandas/tests/arrays/test_integer.py" 

--- a/projects/pandas/bugs/72/bug.info
+++ b/projects/pandas/bugs/72/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a9b61a9" 
+buggy_commit_id="a9b61a9c33f97554cf3dde6272644fc985db8dfb"
 fixed_commit_id="0c50950f2a7e32887eff6be5979f09772091e1de"  
 test_file="pandas/tests/frame/indexing/test_categorical.py" 

--- a/projects/pandas/bugs/73/bug.info
+++ b/projects/pandas/bugs/73/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f1d7ac6" 
+buggy_commit_id="f1d7ac6c2e0e7f2da10c5d48a1e5ff5922750b56"
 fixed_commit_id="6f93898d32c0f1fdb382d1e9dee434c158998374"  
 test_file="pandas/tests/frame/test_arithmetic.py" 

--- a/projects/pandas/bugs/74/bug.info
+++ b/projects/pandas/bugs/74/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="9a211aa" 
+buggy_commit_id="9a211aae9f710db23c9113aea0251e2758904755"
 fixed_commit_id="839e7f1416148caff518a5b75327a2480a2bbbb4"  
 test_file="pandas/tests/indexes/timedeltas/test_constructors.py" 

--- a/projects/pandas/bugs/75/bug.info
+++ b/projects/pandas/bugs/75/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="2038d7a" 
+buggy_commit_id="2038d7a4124384d5bad1ca1d4c38a226be473407"
 fixed_commit_id="9a211aae9f710db23c9113aea0251e2758904755"  
 test_file="pandas/tests/indexes/period/test_indexing.py" 

--- a/projects/pandas/bugs/76/bug.info
+++ b/projects/pandas/bugs/76/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="4da554f" 
+buggy_commit_id="4da554f75fae1d816a3eae8041ddac48904666d8"
 fixed_commit_id="47922d3b00edfc264f73b1484589734bbd077c11"  
 test_file="pandas/tests/io/json/test_pandas.py" 

--- a/projects/pandas/bugs/77/bug.info
+++ b/projects/pandas/bugs/77/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="667bb37" 
+buggy_commit_id="667bb374067ae2c77dbaf40f43fce9adf2038018"
 fixed_commit_id="daef69c1366e31c3c49aea6f2e55f577d0c832fd"  
 test_file="pandas/tests/arithmetic/test_array_ops.py" 

--- a/projects/pandas/bugs/78/bug.info
+++ b/projects/pandas/bugs/78/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f5aa542" 
+buggy_commit_id="f5aa5425549c5b39e7bc0a154b4d585a9375a571"
 fixed_commit_id="bd6b395a1e8fb7d099fa17a0e24f8fe3b628822c"  
 test_file="pandas/tests/frame/test_subclass.py" 

--- a/projects/pandas/bugs/79/bug.info
+++ b/projects/pandas/bugs/79/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="38ea154" 
+buggy_commit_id="38ea15482aaef03647e4bac6ccb49a4667a0e2ac"
 fixed_commit_id="0b0cd08524e4472eb15835c2b91621dc0a6eeeb0"  
 test_file="pandas/tests/indexes/datetimes/test_indexing.py" 

--- a/projects/pandas/bugs/8/bug.info
+++ b/projects/pandas/bugs/8/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="ddbeca6"
+buggy_commit_id="ddbeca610f0064f8860aa428db3df2e6d22cb833"
 fixed_commit_id="d09f20e29bdfa82f5efc071986e2633001d552f6"
 test_file="pandas/tests/frame/methods/test_replace.py"

--- a/projects/pandas/bugs/80/bug.info
+++ b/projects/pandas/bugs/80/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="d0d93db" 
+buggy_commit_id="d0d93dbf9cebcb26924a276f4dc37651cb3844f9"
 fixed_commit_id="351760c0655b6c383e449cf857b9a718e3545229"  
 test_file="pandas/tests/arrays/sparse/test_arithmetics.py" 

--- a/projects/pandas/bugs/81/bug.info
+++ b/projects/pandas/bugs/81/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="b529857" 
+buggy_commit_id="b5298572269504d461dd4798172b5f1c2f6b5cc1"
 fixed_commit_id="339edcdb7ecc6edc6fde1b7d1413dbb746d2bcca"  
 test_file="pandas/tests/arrays/test_integer.py" 

--- a/projects/pandas/bugs/82/bug.info
+++ b/projects/pandas/bugs/82/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="6f395ad" 
+buggy_commit_id="6f395ad4215cafe6c1fa237e6a018aa32264985d"
 fixed_commit_id="e83a6bddac8c89b144dfe0783594dd332c5b3030"  
 test_file="pandas/tests/reshape/merge/test_merge.py" 

--- a/projects/pandas/bugs/83/bug.info
+++ b/projects/pandas/bugs/83/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="964400d" 
+buggy_commit_id="964400d20fdebe97868e511fc128be9188f56064"
 fixed_commit_id="7ffcf9d6753e7de2c5318e8e0ecdc63586d502f3"  
 test_file="pandas/tests/reshape/test_concat.py" 

--- a/projects/pandas/bugs/84/bug.info
+++ b/projects/pandas/bugs/84/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="469b4b7" 
+buggy_commit_id="469b4b71fd2eaf9c04b40e270ceec2f1dd7961ce"
 fixed_commit_id="24d7c06130f9c2aeebedc26971b244ce076f7d0a"  
 test_file="pandas/tests/frame/test_reshape.py" 

--- a/projects/pandas/bugs/85/bug.info
+++ b/projects/pandas/bugs/85/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f1aaf62" 
+buggy_commit_id="f1aaf62f181e19d716bc0ade018a8081c1c02d83"
 fixed_commit_id="29edd119d31a9ee7d4f89e8c1dc8af96f0c19dce"  
 test_file="pandas/tests/groupby/test_apply.py" 

--- a/projects/pandas/bugs/86/bug.info
+++ b/projects/pandas/bugs/86/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="55cfabb" 
+buggy_commit_id="55cfabb630b2c205bd25fcaf999d85beaf7f7163"
 fixed_commit_id="f792d8c50ee456aa8aa2ae406d8e6b8843f45614"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/87/bug.info
+++ b/projects/pandas/bugs/87/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="641346c" 
+buggy_commit_id="641346cd27f4788f0c628170d0178eab6f404c81"
 fixed_commit_id="a890239b7020dec714d9819b718d83f786bfda34"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/88/bug.info
+++ b/projects/pandas/bugs/88/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="698920f" 
+buggy_commit_id="698920f1d7ec40eaa025b7ccd0e4e2f78bcb89c8"
 fixed_commit_id="586bcb16023ae870b0ad7769f6d9077903705486"  
 test_file="pandas/tests/reshape/test_pivot.py" 

--- a/projects/pandas/bugs/89/bug.info
+++ b/projects/pandas/bugs/89/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="0dc317f" 
+buggy_commit_id="0dc317fd76190e1932e2f7b81ed30657a23d918e"
 fixed_commit_id="feaa5033b7810f7775fd4806c27b2f9f1e9b5051"  
 test_file="pandas/tests/frame/test_reshape.py" 

--- a/projects/pandas/bugs/9/bug.info
+++ b/projects/pandas/bugs/9/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3"
-buggy_commit_id="c557ab5"
+buggy_commit_id="c557ab5b00f8cdc1d39f1087320b35d797c5f274"
 fixed_commit_id="ebb727e5cd8865a7f5d6cfb4b22d3278b6bf5e6b"
 test_file="pandas/tests/indexes/categorical/test_indexing.py"

--- a/projects/pandas/bugs/90/bug.info
+++ b/projects/pandas/bugs/90/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="a474a01" 
+buggy_commit_id="a474a01bc98db9a71d74cb117cb8eb26bf12869d"
 fixed_commit_id="1c3d64bae7c07b5ae1be337e0ebd751385b7ce27"  
 test_file="pandas/tests/io/test_pickle.py" 

--- a/projects/pandas/bugs/91/bug.info
+++ b/projects/pandas/bugs/91/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="5c12d4f" 
+buggy_commit_id="5c12d4fd41ec3bb1fd4190413bd61b4b5f02047f"
 fixed_commit_id="cb9a1c7d0319c34a97247973ca96af53ead8033a"  
 test_file="pandas/tests/arrays/test_timedeltas.py" 

--- a/projects/pandas/bugs/92/bug.info
+++ b/projects/pandas/bugs/92/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f2b213c" 
+buggy_commit_id="f2b213c0cd77330056f5efab277d035b2f989759"
 fixed_commit_id="511a2847f4330c54d079d04b3cac4febe0fe9915"  
 test_file="pandas/tests/frame/methods/test_asof.py" 

--- a/projects/pandas/bugs/93/bug.info
+++ b/projects/pandas/bugs/93/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="425c2fb" 
+buggy_commit_id="425c2fbf29c71f304c30180e06a3a1b2c35ff9b4"
 fixed_commit_id="bde25278ccf4fb2d751c5e99e24b2270e0d62ef7"  
 test_file="pandas/tests/indexes/period/test_indexing.py;" 

--- a/projects/pandas/bugs/94/bug.info
+++ b/projects/pandas/bugs/94/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8803056" 
+buggy_commit_id="8803056481b2a2ada1b0babc31002d7dce35060c"
 fixed_commit_id="613df15047887957f5964d2a6ce59ea20b0c4c91"  
 test_file="pandas/tests/indexes/datetimes/test_constructors.py" 

--- a/projects/pandas/bugs/95/bug.info
+++ b/projects/pandas/bugs/95/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="036dc88" 
+buggy_commit_id="036dc8863e20632c6497cc69e341be41ad0be172"
 fixed_commit_id="c99dfea33612f44e97c2365f78c0ca6d5754a1bc"  
 test_file="pandas/tests/arithmetic/test_period.py" 

--- a/projects/pandas/bugs/96/bug.info
+++ b/projects/pandas/bugs/96/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="5e488a0" 
+buggy_commit_id="5e488a01c885873cdb03598578f30e5788180774"
 fixed_commit_id="6d67cf9f02dd22cc870fd407f569197512700203"  
 test_file="pandas/tests/indexes/datetimes/test_date_range.py" 

--- a/projects/pandas/bugs/97/bug.info
+++ b/projects/pandas/bugs/97/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="f9e524c" 
+buggy_commit_id="f9e524cf150cebbfec57252bb8b3c7a9bea39819"
 fixed_commit_id="6f690b088190581552e04c53288819472fdb2dbe"  
 test_file="pandas/tests/indexes/timedeltas/test_setops.py" 

--- a/projects/pandas/bugs/98/bug.info
+++ b/projects/pandas/bugs/98/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="8105a7e" 
+buggy_commit_id="8105a7e8282edba5c98138ac09ed2c3bec7823e6"
 fixed_commit_id="09e4b780f09c5aa72bb2a6ae2832612f81dc047f"  
 test_file="pandas/tests/indexes/period/test_constructors.py" 

--- a/projects/pandas/bugs/99/bug.info
+++ b/projects/pandas/bugs/99/bug.info
@@ -1,4 +1,4 @@
 python_version="3.8.3" 
-buggy_commit_id="2b1b3da" 
+buggy_commit_id="2b1b3da4c68fdaf9637d12706c5ba3de1a9b20de"
 fixed_commit_id="b8043724c48890e86fda0265ad5b6ac3d31f1940"  
 test_file="pandas/tests/indexes/datetimes/test_tools.py" 


### PR DESCRIPTION
This PR expands the abbreviated `buggy_commit_id` values in the pandas dataset to full 40-character commit SHAs.

This change does not affect behavior.
However, for maintainability, it is preferable to standardize the format with the rest of the dataset and avoid ambiguity from shortened hashes.